### PR TITLE
Main Menu Screen + Config Screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,23 +81,23 @@ Minecraft is a sandbox video game that allows players to explore a procedurally 
 ## Contributing
 To get started contributing to this project, please read the [Contributing Guide](./docs/CONTRIBUTING.md).
 
-### Authors and acknowledgment
-#### Software Development
+## Authors and acknowledgment
+### Software Development
 Name | Main Contributions
 ------------ | -------------
 Daniel McCoy Stephenson (Creator) | Conceived the game concept, wrote the game's codebase, wrote the game's documentation & managed the project's development
 Pasarus | Participated in brainstorming sessions & participated in PR reviews
 
-#### Other
+### Other
 Name | Main Contributions
 ------------ | -------------
 William McGonagle (Creator) | Reached out to Preponderous Software to collaborate on the project, wrote the license, participated in brainstorming sessions & managed the project's marketing/publishing
 Phil Garner | Participated in brainstorming sessions & provided feedback on economic mechanics
 Nathan Gates | Playtested the game & participated in brainstorming sessions
-Ezekiel | Participated in brainstorming sessions
+Ezekiel Martinez | Playtested the game & participated in brainstorming sessions
 Sshinx | Contributed custom 3D models including trees, saplings & rocks
 
-### Roles
+## Roles
 Preponderous Software and the Fairfield Programming Association are the two organizations that are collaborating on this project.
 
 ### Developing

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following controls are available in the game:
 | `F4` | Spawn money |
 | `F5` | Spawn wood |
 | `F6` | Teleport all pawns to you |
+| `F12` | Take screenshot |
 
 ## Game Systems
 There are a number of systems that will be implemented in the game. These systems will be used to create an engaging gameplay experience. Details can be found in the [Systems Document](./docs/SYSTEMS.md).

--- a/src/c#/main/BeyondNations.cs
+++ b/src/c#/main/BeyondNations.cs
@@ -42,6 +42,8 @@ namespace beyondnations {
         }
 
         public void Update() {
+            captureScreenshotIfKeyPressed();
+
             if (currentScreen == ScreenType.TITLE) {
                 if (Input.anyKey) {
                     currentScreen = ScreenType.MAIN_MENU;
@@ -85,8 +87,6 @@ namespace beyondnations {
             else {
                 throw new Exception("Unknown screen type: " + currentScreen);
             }
-
-            captureScreenshotIfKeyPressed();
         }
 
         public void FixedUpdate() {
@@ -111,6 +111,8 @@ namespace beyondnations {
         }
 
         public void OnGUI() {
+            displayVersionNumber();
+            
             if (currentScreen == ScreenType.TITLE) {
                 titleScreen.OnGUI();
             }
@@ -132,12 +134,6 @@ namespace beyondnations {
             else {
                 throw new Exception("Unknown screen type: " + currentScreen);
             }
-
-            // put version number in bottom left corner
-            GUIStyle style = new GUIStyle();
-            style.normal.textColor = Color.white;
-            style.fontSize = 12;
-            GUI.Label(new Rect(10, Screen.height - 20, 100, 20), version, style);
         }
 
         private void initializeWorldScreen() {
@@ -158,6 +154,14 @@ namespace beyondnations {
                 ScreenCapture.CaptureScreenshot(path);
                 Debug.Log("Screenshot saved to " + path);
             }
+        }
+
+        private void displayVersionNumber() {
+            // put version number in bottom left corner
+            GUIStyle style = new GUIStyle();
+            style.normal.textColor = Color.white;
+            style.fontSize = 12;
+            GUI.Label(new Rect(10, Screen.height - 20, 100, 20), "v" + version, style);
         }
     }
 }

--- a/src/c#/main/BeyondNations.cs
+++ b/src/c#/main/BeyondNations.cs
@@ -19,6 +19,8 @@ namespace beyondnations {
         private GameConfig gameConfig;
 
         private ScreenType currentScreen = ScreenType.TITLE;
+        
+        private string version = "0.3.0-alpha";
 
         public bool runTests;
         public bool debugMode;
@@ -130,6 +132,12 @@ namespace beyondnations {
             else {
                 throw new Exception("Unknown screen type: " + currentScreen);
             }
+
+            // put version number in bottom left corner
+            GUIStyle style = new GUIStyle();
+            style.normal.textColor = Color.white;
+            style.fontSize = 12;
+            GUI.Label(new Rect(10, Screen.height - 20, 100, 20), version, style);
         }
 
         private void initializeWorldScreen() {
@@ -137,15 +145,18 @@ namespace beyondnations {
         }
 
         private void captureScreenshotIfKeyPressed() {
-            if (Input.GetKeyDown(KeyCode.F12)) {
+            if (Input.GetKeyDown(KeyBindings.takeScreenshot)) {
+                // generate filename
                 string timestamp = DateTime.Now.ToString("yyyyMMddHHmmssffff");
                 string filename = "screenshot_" + timestamp + ".png";
                 string path = "C:\\BeyondNations\\Screenshots\\" + filename;
 
                 // create directory if it doesn't exist
-                System.IO.Directory.CreateDirectory("C:\\BeyondNations\\Screenshots\\"); // TODO: pull this in from config
+                System.IO.Directory.CreateDirectory(gameConfig.getBeyondNationsDirectoryPath() + "\\Screenshots\\");
 
+                // take screenshot
                 ScreenCapture.CaptureScreenshot(path);
+                Debug.Log("Screenshot saved to " + path);
             }
         }
     }

--- a/src/c#/main/BeyondNations.cs
+++ b/src/c#/main/BeyondNations.cs
@@ -13,6 +13,8 @@ namespace beyondnations {
         private TitleScreen titleScreen;
         private WorldScreen worldScreen;
         private PauseScreen pauseScreen;
+        private MainMenuScreen mainMenuScreen;
+        private ConfigScreen configScreen;
     
         private GameConfig gameConfig;
 
@@ -32,13 +34,15 @@ namespace beyondnations {
             }
             titleScreen = new TitleScreen();
             pauseScreen = new PauseScreen();
+            mainMenuScreen = new MainMenuScreen();
+            configScreen = new ConfigScreen();
             gameConfig = new GameConfig();
         }
 
         public void Update() {
             if (currentScreen == ScreenType.TITLE) {
                 if (Input.anyKey) {
-                    currentScreen = ScreenType.WORLD;
+                    currentScreen = ScreenType.MAIN_MENU;
                 }
                 return;
             }
@@ -58,9 +62,29 @@ namespace beyondnations {
                     return;
                 }
             }
+            else if (currentScreen == ScreenType.MAIN_MENU) {
+                if (Input.GetKeyDown(KeyCode.Escape)) {
+                    // exit
+                    Application.Quit();
+
+                    // stop
+                    #if UNITY_EDITOR
+                    UnityEditor.EditorApplication.isPlaying = false;
+                    #endif
+                    return;
+                }
+            }
+            else if (currentScreen == ScreenType.CONFIG) {
+                if (Input.GetKeyDown(KeyCode.Escape)) {
+                    currentScreen = ScreenType.MAIN_MENU;
+                    return;
+                }
+            }
             else {
                 throw new Exception("Unknown screen type: " + currentScreen);
             }
+
+            captureScreenshotIfKeyPressed();
         }
 
         public void FixedUpdate() {
@@ -71,6 +95,12 @@ namespace beyondnations {
                 worldScreen.FixedUpdate();
             }
             else if (currentScreen == ScreenType.PAUSE) {
+                return;
+            }
+            else if (currentScreen == ScreenType.MAIN_MENU) {
+                return;
+            }
+            else if (currentScreen == ScreenType.CONFIG) {
                 return;
             }
             else {
@@ -91,6 +121,12 @@ namespace beyondnations {
             else if (currentScreen == ScreenType.PAUSE) {
                 pauseScreen.OnGUI();
             }
+            else if (currentScreen == ScreenType.MAIN_MENU) {
+                currentScreen = mainMenuScreen.OnGUI();
+            }
+            else if (currentScreen == ScreenType.CONFIG) {
+                currentScreen = configScreen.OnGUI(gameConfig);
+            }
             else {
                 throw new Exception("Unknown screen type: " + currentScreen);
             }
@@ -98,6 +134,19 @@ namespace beyondnations {
 
         private void initializeWorldScreen() {
             worldScreen = new WorldScreen(gameConfig, debugMode);
+        }
+
+        private void captureScreenshotIfKeyPressed() {
+            if (Input.GetKeyDown(KeyCode.F12)) {
+                string timestamp = DateTime.Now.ToString("yyyyMMddHHmmssffff");
+                string filename = "screenshot_" + timestamp + ".png";
+                string path = "C:\\BeyondNations\\Screenshots\\" + filename;
+
+                // create directory if it doesn't exist
+                System.IO.Directory.CreateDirectory("C:\\BeyondNations\\Screenshots\\"); // TODO: pull this in from config
+
+                ScreenCapture.CaptureScreenshot(path);
+            }
         }
     }
 }

--- a/src/c#/main/config/GameConfig.cs
+++ b/src/c#/main/config/GameConfig.cs
@@ -1,50 +1,93 @@
 namespace beyondnations {
 
     public class GameConfig {
+        
+        // TODO: create "ConfigOption" class & make this more flexible
+
+        // modifiable
         private int chunkSize;
         private int locationScale;
+        private bool respawnPawns;
+        private bool keepInventoryOnDeath;
+        private bool lagPreventionEnabled;
+
+        // non-modifiable
         private int statusExpirationTicks;
         private int playerWalkSpeed;
         private int playerRunSpeed;
-        private bool respawnPawns;
-        private bool keepInventoryOnDeath;
         private int ticksBetweenBehaviorCalculations;
         private int ticksBetweenBehaviorExecutions;
         private int minDistanceBetweenSettlements;
         private int settlementJoinRange;
         private float settlementMetabolismMultiplier;
         private int renderDistance;
-        private bool lagPreventionEnabled;
         private int maxNumEntities;
         private int maxNumChunks;
 
         public GameConfig() {
+            // modifiable
             chunkSize = 7;
             locationScale = 15;
+            respawnPawns = false;
+            keepInventoryOnDeath = true;
+            lagPreventionEnabled = true;
+
+            // non-modifiable
             statusExpirationTicks = 500;
             playerWalkSpeed = 25;
             playerRunSpeed = 50;
-            respawnPawns = false;
-            keepInventoryOnDeath = true;
             ticksBetweenBehaviorCalculations = 1000;
             ticksBetweenBehaviorExecutions = 5;
             minDistanceBetweenSettlements = 250;
             settlementJoinRange = 500;
             settlementMetabolismMultiplier = 0.8f;
             renderDistance = 200;
-            lagPreventionEnabled = true;
             maxNumEntities = 100000;
             maxNumChunks = 10000;
         }
 
+        // modifiable
         public int getChunkSize() {
             return chunkSize;
+        }
+
+        public void setChunkSize(int chunkSize) {
+            this.chunkSize = chunkSize;
         }
 
         public int getLocationScale() {
             return locationScale;
         }
 
+        public void setLocationScale(int locationScale) {
+            this.locationScale = locationScale;
+        }
+
+        public bool getRespawnPawns() {
+            return respawnPawns;
+        }
+
+        public void setRespawnPawns(bool respawnPawns) {
+            this.respawnPawns = respawnPawns;
+        }
+
+        public bool getKeepInventoryOnDeath() {
+            return keepInventoryOnDeath;
+        }
+
+        public void setKeepInventoryOnDeath(bool keepInventoryOnDeath) {
+            this.keepInventoryOnDeath = keepInventoryOnDeath;
+        }
+
+        public bool getLagPreventionEnabled() {
+            return lagPreventionEnabled;
+        }
+
+        public void setLagPreventionEnabled(bool lagPreventionEnabled) {
+            this.lagPreventionEnabled = lagPreventionEnabled;
+        }
+
+        // non-modifiable
         public int getStatusExpirationTicks() {
             return statusExpirationTicks;
         }
@@ -55,14 +98,6 @@ namespace beyondnations {
 
         public int getPlayerRunSpeed() {
             return playerRunSpeed;
-        }
-
-        public bool getRespawnPawns() {
-            return respawnPawns;
-        }
-
-        public bool getKeepInventoryOnDeath() {
-            return keepInventoryOnDeath;
         }
 
         public int getTicksBetweenBehaviorCalculations() {
@@ -87,10 +122,6 @@ namespace beyondnations {
 
         public int getRenderDistance() {
             return renderDistance;
-        }
-
-        public bool getLagPreventionEnabled() {
-            return lagPreventionEnabled;
         }
 
         public int getMaxNumEntities() {

--- a/src/c#/main/config/GameConfig.cs
+++ b/src/c#/main/config/GameConfig.cs
@@ -23,6 +23,7 @@ namespace beyondnations {
         private int renderDistance;
         private int maxNumEntities;
         private int maxNumChunks;
+        private string beyondNationsDirectoryPath;
 
         public GameConfig() {
             // modifiable
@@ -44,6 +45,7 @@ namespace beyondnations {
             renderDistance = 200;
             maxNumEntities = 100000;
             maxNumChunks = 10000;
+            beyondNationsDirectoryPath = "C:\\BeyondNations";
         }
 
         // modifiable
@@ -130,6 +132,10 @@ namespace beyondnations {
 
         public int getMaxNumChunks() {
             return maxNumChunks;
+        }
+
+        public string getBeyondNationsDirectoryPath() {
+            return beyondNationsDirectoryPath;
         }
     }
 }

--- a/src/c#/main/config/KeyBindings.cs
+++ b/src/c#/main/config/KeyBindings.cs
@@ -27,5 +27,6 @@ namespace beyondnations {
         public static readonly KeyCode spawnMoney = KeyCode.F4;
         public static readonly KeyCode spawnWood = KeyCode.F5;
         public static readonly KeyCode teleportAllToPlayer = KeyCode.F6;
+        public static readonly KeyCode takeScreenshot = KeyCode.F12;
     }
 }

--- a/src/c#/main/screens/ConfigScreen.cs
+++ b/src/c#/main/screens/ConfigScreen.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace beyondnations {
+
+    /**
+    * The config screen of the game.
+    */
+    public class ConfigScreen {
+
+        public ScreenType OnGUI(GameConfig gameConfig) {
+            int width = Screen.width;
+            int height = Screen.height;
+
+            int centerX = width / 2;
+            int centerY = height / 2;
+
+            int titleWidth = 200;
+            int titleHeight = 100;
+            int titleX = centerX - titleWidth / 2;
+            int titleY = centerY/2 - titleHeight / 2;
+
+            int buttonWidth = 100;
+            int buttonHeight = 20;
+            int buttonX = centerX - buttonWidth / 2;
+            int buttonY = centerY + buttonHeight / 2;
+
+            // draw "Config" title
+            GUI.Label(new Rect(titleX, titleY, titleWidth, titleHeight), "Config", new GUIStyle() {
+                fontSize = Screen.height / 15,
+                alignment = TextAnchor.MiddleCenter
+            });
+            
+            // chunk size (increment by 1, allow 7-17)
+            GUI.Label(new Rect(buttonX, buttonY + buttonHeight * 1, buttonWidth, buttonHeight), "Chunk Size");
+            if (GUI.Button(new Rect(buttonX + buttonWidth, buttonY + buttonHeight * 1, buttonWidth, buttonHeight), gameConfig.getChunkSize().ToString())) {
+                gameConfig.setChunkSize(gameConfig.getChunkSize() + 1);
+
+                if (gameConfig.getChunkSize() > 17) {
+                    gameConfig.setChunkSize(7);
+                }
+            }
+
+            // location scale (increment by 1, allow 7-17)
+            GUI.Label(new Rect(buttonX, buttonY + buttonHeight * 2, buttonWidth, buttonHeight), "Location Scale");
+            if (GUI.Button(new Rect(buttonX + buttonWidth, buttonY + buttonHeight * 2, buttonWidth, buttonHeight), gameConfig.getLocationScale().ToString())) {
+                gameConfig.setLocationScale(gameConfig.getLocationScale() + 1);
+
+                if (gameConfig.getLocationScale() > 17) {
+                    gameConfig.setLocationScale(7);
+                }
+            }
+
+            // respawn pawns (true or false)
+            GUI.Label(new Rect(buttonX, buttonY + buttonHeight * 3, buttonWidth, buttonHeight), "Respawn Pawns");
+            if (GUI.Button(new Rect(buttonX + buttonWidth, buttonY + buttonHeight * 3, buttonWidth, buttonHeight), gameConfig.getRespawnPawns().ToString())) {
+                gameConfig.setRespawnPawns(!gameConfig.getRespawnPawns());
+            }
+
+            // keep inventory on death (true or false)
+            GUI.Label(new Rect(buttonX, buttonY + buttonHeight * 4, buttonWidth, buttonHeight), "Keep Inventory");
+            if (GUI.Button(new Rect(buttonX + buttonWidth, buttonY + buttonHeight * 4, buttonWidth, buttonHeight), gameConfig.getKeepInventoryOnDeath().ToString())) {
+                gameConfig.setKeepInventoryOnDeath(!gameConfig.getKeepInventoryOnDeath());
+            }
+
+            // lag prevention (true or false)
+            GUI.Label(new Rect(buttonX, buttonY + buttonHeight * 5, buttonWidth, buttonHeight), "Lag Prevention");
+            if (GUI.Button(new Rect(buttonX + buttonWidth, buttonY + buttonHeight * 5, buttonWidth, buttonHeight), gameConfig.getLagPreventionEnabled().ToString())) {
+                gameConfig.setLagPreventionEnabled(!gameConfig.getLagPreventionEnabled());
+            }
+
+            // draw back at bottom center (1 buttonheight from bottom)
+            if (GUI.Button(new Rect(buttonX, Screen.height - buttonHeight * 2, buttonWidth, buttonHeight), "Back")) {
+                return ScreenType.MAIN_MENU;
+            }
+
+            return ScreenType.CONFIG;
+        }
+    }
+}

--- a/src/c#/main/screens/ConfigScreen.cs.meta
+++ b/src/c#/main/screens/ConfigScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 767cc249d93a8364b82ddea21304d56b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/screens/MainMenuScreen.cs
+++ b/src/c#/main/screens/MainMenuScreen.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace beyondnations {
+
+    /**
+    * The main menu screen of the game.
+    */
+    public class MainMenuScreen {
+
+        public ScreenType OnGUI() {
+            int width = Screen.width;
+            int height = Screen.height;
+
+            int centerX = width / 2;
+            int centerY = height / 2;
+
+            int titleWidth = 200;
+            int titleHeight = 100;
+            int titleX = centerX - titleWidth / 2;
+            int titleY = centerY/2 - titleHeight / 2;
+
+            int buttonWidth = 100;
+            int buttonHeight = 50;
+            int buttonX = centerX - buttonWidth / 2;
+            int buttonY = centerY + buttonHeight / 2;
+
+            // draw "Beyond Nations" in top center in big font
+            GUI.Label(new Rect(titleX, titleY, titleWidth, titleHeight), "Beyond Nations", new GUIStyle() {
+                fontSize = Screen.height / 15,
+                alignment = TextAnchor.MiddleCenter
+            });
+
+            // draw start button at center
+            if (GUI.Button(new Rect(buttonX, buttonY, buttonWidth, buttonHeight), "Start")) {
+                return ScreenType.WORLD;
+            }
+
+            // draw config button at center
+            if (GUI.Button(new Rect(buttonX, buttonY + buttonHeight * 2, buttonWidth, buttonHeight), "Config")) {
+                return ScreenType.CONFIG;
+            }
+
+            // draw exit at bottom center
+            if (GUI.Button(new Rect(buttonX, buttonY + buttonHeight * 4, buttonWidth, buttonHeight), "Exit")) {
+                Application.Quit();
+
+                // stop
+                #if UNITY_EDITOR
+                UnityEditor.EditorApplication.isPlaying = false;
+                #endif
+            }
+            return ScreenType.MAIN_MENU;
+        }
+    }
+}

--- a/src/c#/main/screens/MainMenuScreen.cs.meta
+++ b/src/c#/main/screens/MainMenuScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e46045051ac1b14b8d4b7a3b506653c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/screens/ScreenType.cs
+++ b/src/c#/main/screens/ScreenType.cs
@@ -3,6 +3,8 @@ namespace beyondnations {
     public enum ScreenType {
         TITLE,
         WORLD,
-        PAUSE
+        PAUSE,
+        MAIN_MENU,
+        CONFIG
     }
 }

--- a/src/c#/main/screens/TitleScreen.cs
+++ b/src/c#/main/screens/TitleScreen.cs
@@ -21,23 +21,12 @@ namespace beyondnations {
             int titleWidth = 200;
             int titleHeight = 100;
             int titleX = centerX - titleWidth / 2;
-            int titleY = centerY/2 - titleHeight / 2;
-
-            int buttonWidth = 100;
-            int buttonHeight = 50;
-            int buttonX = centerX - buttonWidth / 2;
-            int buttonY = centerY + buttonHeight / 2;
+            int titleY = centerY - titleHeight;
 
             // draw title in top center in large font
             GUI.Label(new Rect(titleX, titleY, titleWidth, titleHeight), "Beyond Nations", new GUIStyle() {
                 fontSize = Screen.height / 10,
                 fontStyle = FontStyle.Bold,
-                alignment = TextAnchor.MiddleCenter
-            });
-
-            // draw "press any key to start" in bottom center in small font
-            GUI.Label(new Rect(titleX, buttonY, titleWidth, titleHeight), "(Press any key to start)", new GUIStyle() {
-                fontSize = Screen.height / 30,
                 alignment = TextAnchor.MiddleCenter
             });
         }


### PR DESCRIPTION
## Changes
The main menu screen has been added between the title screen & the world screen. From the main menu the user can go to the config screen (which allows them to modify some config options for the game) or they can exit the game. From the config screen the user can go back to the main menu.

## Additional Changes
- It is now possible to take a screenshot by pressing `F12`.
- The version is now displayed in the bottom left corner.

## Issues
closes #177
closes #180

## Screenshots
![screenshot_202308152240144255](https://github.com/Preponderous-Software/Beyond-Nations/assets/21204351/679aba14-aa11-4089-a48e-d2782af784fb)
![screenshot_202308152240159758](https://github.com/Preponderous-Software/Beyond-Nations/assets/21204351/67d4404a-e41c-47c2-9c86-3412ceefa6b4)
